### PR TITLE
Add reference to symfony bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ If you're looking to integrate Sapient into an existing framework:
   * `composer require paragonie/slim-sapient`
 * [Zend Framework Diactoros Sapient Adapter](https://github.com/paragonie/zend-diactoros-sapient)
   * `composer require paragonie/zend-diactoros-sapient`
+* [Symfony bundle](https://github.com/lepiaf/sapient-bundle)
+  * `composer require lepiaf/sapient-bundle`
 
 If your framework correctly implements PSR-7, you most likely do not need an adapter. However,
 some adapters provide convenience methods that make rapid development easier.


### PR DESCRIPTION
Hi,

I really like your work on PHP ecosystem and I would like to help you to spread the word.

As a developer who really enjoy Symfony framework, I'm working on a bundle to help using and configure sapient as an easy way for Symfony.

It is still in development and I'm still thinking on how to make usage of this bundle easy.

My first MVP is to automate generation of key pair and sign all response automatically. I will also add a feature to encrypt and verify response.

I'm open to any suggestion and improvement.

Regards,
