### PR TITLE
Built-in method for verifying symmetric authentication uses wrong header

### DIFF
--- a/src/Sapient.php
+++ b/src/Sapient.php
@@ -460,10 +460,10 @@ class Sapient
         SharedAuthenticationKey $key
     ): ResponseInterface {
         /** @var array<int, string> */
-        $headers = $response->getHeader((string) static::HEADER_SIGNATURE_NAME);
+        $headers = $response->getHeader((string) static::HEADER_AUTH_NAME);
         if (!$headers) {
             throw new HeaderMissingException(
-                'No signed response header (' . (string) static::HEADER_SIGNATURE_NAME . ') found.'
+                'No signed response header (' . (string) static::HEADER_AUTH_NAME . ') found.'
             );
         }
 

--- a/tests/SapientAuthenticateTest.php
+++ b/tests/SapientAuthenticateTest.php
@@ -1,0 +1,102 @@
+<?php
+namespace ParagonIE\Sapient\UnitTests;
+
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use ParagonIE\ConstantTime\Base64UrlSafe;
+use ParagonIE\Sapient\Adapter\Guzzle;
+use ParagonIE\Sapient\CryptographyKeys\{
+    SharedAuthenticationKey
+};
+use ParagonIE\Sapient\Sapient;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class SapientTest
+ * @package ParagonIE\Sapient\UnitTests
+ */
+class SapientAuthenticateTest extends TestCase
+{
+    /** @var Sapient */
+    protected $sapient;
+
+    /** @var SharedAuthenticationKey */
+    protected $sharedAuthenticationKey;
+
+    /**
+     * Setup the class properties
+     */
+    public function setUp()
+    {
+        $this->sapient = new Sapient(new Guzzle());
+
+        $this->sharedAuthenticationKey = SharedAuthenticationKey::generate();
+    }
+
+    private function getSampleObjects(): array
+    {
+        return [
+            [],
+            ['test' => 'abcdefg'],
+            ['random' => Base64UrlSafe::encode(
+                \random_bytes(
+                    \random_int(1, 100)
+                )
+            )
+            ],
+            ['structued' => [
+                'abc' => 'def',
+                'o' => null,
+                'ghi' => ['j', 'k', 'l'],
+                'm' => 1234,
+                'n' => 56.78,
+                'p' => ['q' => ['r' => []]]
+            ]]
+        ];
+    }
+
+    /**
+     * @covers \ParagonIE\Sapient\Adapter\Guzzle::createSymmetricAuthenticatedJsonRequest()
+     * @covers \ParagonIE\Sapient\Sapient::verifySymmetricAuthenticatedRequest()
+     */
+    public function testSignedJsonRequest()
+    {
+        foreach ($this->getSampleObjects() as $obj) {
+            $guzzle = new Guzzle();
+            $request = $guzzle->createSymmetricAuthenticatedJsonRequest(
+                'POST',
+                '/',
+                $obj,
+                $this->sharedAuthenticationKey
+            );
+            $decoded = $this->sapient->verifySymmetricAuthenticatedRequest(
+                $request,
+                $this->sharedAuthenticationKey
+            );
+            $body = json_decode((string)$decoded->getBody(), true);
+            $this->assertSame($obj, $body);
+        }
+    }
+
+    /**
+     * @covers Sapient::createSignedJsonRequest()
+     * @covers Sapient::verifySignedRequest()
+     */
+    public function testSignedJsonResponse()
+    {
+        foreach ($this->getSampleObjects() as $obj) {
+            $guzzle = new Guzzle();
+            $response = $guzzle->createSymmetricAuthenticatedJsonResponse(
+                200,
+                $obj,
+                $this->sharedAuthenticationKey
+            );
+            $decoded = $this->sapient->verifySymmetricAuthenticatedResponse(
+                $response,
+                $this->sharedAuthenticationKey
+            );
+            $body = json_decode((string)$decoded->getBody(), true);
+            $this->assertSame($obj, $body);
+        }
+    }
+}


### PR DESCRIPTION
The method `\ParagonIE\Sapient\Sapient::verifySymmetricAuthenticatedResponse` uses
the header for Ed25519 public-key signatures. This commit fixes that and adds
a test for the failing scenario (current code).